### PR TITLE
Adding functionallity for sales_start

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Host: bolaget.io
 
    `year_to=[number]`
 
+   `sales_start_from=[date]` - YYYY-MM-DD
+
+   `sales_start_to=[date]` - YYYY-MM-DD
+
    `price_from=[number]`
 
    `price_to=[integer]`
@@ -53,6 +57,7 @@ Host: bolaget.io
       - `price_per_liter:asc|desc`
       - `volume_in_milliliter:asc|desc`
       - `year:asc|desc`
+      - `sales_start:asc|desc`
       - `zip_code:asc|desc`
       - `name:asc|desc`<br><br>
 

--- a/app/models/v1/product.js
+++ b/app/models/v1/product.js
@@ -73,7 +73,7 @@ class Product extends Elastic {
         },
         volume_in_milliliter: { type: 'double', index: 'not_analyzed' },
         price_per_liter: { type: 'double', index: 'not_analyzed' },
-        sales_start: { type: 'string', index: 'not_analyzed' },
+        sales_start: { type: 'date', index: 'not_analyzed'},
         expired: { type: 'boolean', index: 'not_analyzed' },
         product_group: { type: 'string', index: 'analyzed', analyzer: 'swedish' },
         type: { type: 'string', index: 'analyzed', analyzer: 'swedish' },

--- a/app/routes/v1/products.js
+++ b/app/routes/v1/products.js
@@ -21,6 +21,8 @@ export default async (ctx, next) => {
   const assortment = ctx.query.assortment
   const yearFrom = parseInt(ctx.query.year_from, 10) || 0
   const yearTo = parseInt(ctx.query.year_to, 10) || 0
+  const salesStartFrom = ctx.query.sales_start_from
+  const salesStartTo = ctx.query.sales_start_to
   const priceFrom = parseInt(ctx.query.price_from, 10) || 0
   const priceTo = parseInt(ctx.query.price_to, 10) || 0
   const volumeFrom = parseInt(ctx.query.volume_from, 10) || 0
@@ -97,6 +99,10 @@ export default async (ctx, next) => {
     query.bool.must.push(rangeMatch('year', yearFrom, yearTo))
   }
 
+  if (salesStartFrom || salesStartTo) {
+    query.bool.must.push(rangeMatch('sales_start', salesStartFrom, salesStartTo))
+  }
+
   if (priceFrom || priceTo) {
     query.bool.must.push(rangeMatch('price.amount', priceFrom, priceTo))
   }
@@ -122,6 +128,7 @@ export default async (ctx, next) => {
   switch (prop) {
     case 'volume_in_milliliter':
     case 'year':
+    case 'sales_start':
     case 'price_per_liter':
       sort = { [prop]: { order } }
       break


### PR DESCRIPTION
Adds the following parameters

- sales_start_from
- sales_start_to

Enables you to request a range of release dates. e.g. all products released in a given year/month/day

Also enables sorting on sales_start